### PR TITLE
Cnam 266 add liberal fractures

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/MedicalAct.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/MedicalAct.scala
@@ -1,15 +1,12 @@
 package fr.polytechnique.cmap.cnam.etl.events
 
 import java.sql.Timestamp
+
 import org.apache.spark.sql.Row
 
 trait MedicalAct extends AnyEvent with EventBuilder {
 
   val category: EventCategory[MedicalAct]
-
-  def apply(patientID: String, groupID: String, code: String, date: Timestamp): Event[MedicalAct] = {
-    Event(patientID, category, groupID, code, 0.0, date, None)
-  }
 
   def fromRow(
       r: Row,
@@ -17,13 +14,16 @@ trait MedicalAct extends AnyEvent with EventBuilder {
       groupIDCol: String = "groupID",
       codeCol: String = "code",
       dateCol: String = "eventDate"): Event[MedicalAct] = {
-
     apply(
       r.getAs[String](patientIDCol),
       r.getAs[String](groupIDCol),
       r.getAs[String](codeCol),
       r.getAs[Timestamp](dateCol)
     )
+  }
+
+  def apply(patientID: String, groupID: String, code: String, date: Timestamp): Event[MedicalAct] = {
+    Event(patientID, category, groupID, code, 0.0, date, None)
   }
 }
 
@@ -34,7 +34,9 @@ object DcirAct extends MedicalAct {
     val PrivateAmbulatory = "private_ambulatory"
     val PublicAmbulatory = "public_ambulatory"
     val PrivateHospital = "private_hospital"
+    val Liberal = "liberal"
   }
+
 }
 
 object McoCCAMAct extends MedicalAct {

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/MedicalActs.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/MedicalActs.scala
@@ -1,9 +1,9 @@
 package fr.polytechnique.cmap.cnam.etl.extractors.acts
 
-import org.apache.spark.sql.Dataset
 import fr.polytechnique.cmap.cnam.etl.events.{Event, MedicalAct}
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.util.functions.unionDatasets
+import org.apache.spark.sql.{Column, DataFrame, Dataset, functions}
 
 class MedicalActs(config: MedicalActsConfig) {
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/GeneralFractures.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/GeneralFractures.scala
@@ -1,10 +1,10 @@
 package fr.polytechnique.cmap.cnam.study.fall
 
-import org.apache.spark.sql.Dataset
 import fr.polytechnique.cmap.cnam.etl.events._
 import fr.polytechnique.cmap.cnam.etl.transformers.outcomes.OutcomeTransformer
 import fr.polytechnique.cmap.cnam.study.fall.codes.FractureCodes
 import fr.polytechnique.cmap.cnam.util.functions.unionDatasets
+import org.apache.spark.sql.Dataset
 
 /*
  * The rules for this Outcome definition can be found on the following page:

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/HospitalizedFractures.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/HospitalizedFractures.scala
@@ -3,8 +3,8 @@ package fr.polytechnique.cmap.cnam.study.fall
 import fr.polytechnique.cmap.cnam.etl.events._
 import fr.polytechnique.cmap.cnam.etl.transformers.outcomes.OutcomeTransformer
 import fr.polytechnique.cmap.cnam.study.fall.codes.FractureCodes
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.functions._
 
 /*
  * The rules for this Outcome definition can be found on the following page:

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/LiberalFractures.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/LiberalFractures.scala
@@ -1,0 +1,19 @@
+package fr.polytechnique.cmap.cnam.study.fall
+
+import fr.polytechnique.cmap.cnam.etl.events.{DcirAct, Event, MedicalAct, Outcome}
+import fr.polytechnique.cmap.cnam.etl.transformers.outcomes.OutcomeTransformer
+import fr.polytechnique.cmap.cnam.study.fall.codes.FractureCodes
+import org.apache.spark.sql.Dataset
+
+object LiberalFractures  extends OutcomeTransformer with FractureCodes{
+
+  override val outcomeName = "Liberal"
+
+  def transform(events: Dataset[Event[MedicalAct]]): Dataset[Event[Outcome]] = {
+    import events.sqlContext.implicits._
+
+    events
+      .map(event => Outcome(event.patientID, outcomeName, event.start))
+  }
+
+}

--- a/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/MedicalActsSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/MedicalActsSuite.scala
@@ -1,10 +1,12 @@
 package fr.polytechnique.cmap.cnam.etl.extractors.acts
 
 import java.sql.Date
+
 import fr.polytechnique.cmap.cnam.SharedContext
 import fr.polytechnique.cmap.cnam.etl.events._
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.util.functions.makeTS
+import org.apache.spark.sql.functions._
 
 class MedicalActsSuite extends SharedContext {
 
@@ -92,4 +94,49 @@ class MedicalActsSuite extends SharedContext {
     // Then
     assertDSs(expected, result)
   }
+
+
+  "extract" should "find all liberal acts in DCIR" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+
+    // Given
+    val config = MedicalActsConfig(
+      dcirCodes = List("ABCD123")
+    )
+
+    val mcoCE = {
+      val date = new Date(makeTS(2003, 2, 1).getTime)
+      Seq(
+        ("george", "coloscopie", date),
+        ("georgette", "angine", date)
+      ).toDF("NUM_ENQ", "MCO_FMSTC__CCAM_COD", "EXE_SOI_DTD")
+    }
+
+    val dcir = spark.read.parquet("src/test/resources/test-input/DCIR.parquet")
+    val df = dcir.select("NUM_ENQ", "ER_CAM_F__CAM_PRS_IDE", "ER_ETE_F__ETE_GHS_NUM", "ER_ETE_F__ETE_TYP_COD", "EXE_SOI_DTD", "ER_ETE_F__ETE_NAT_FSJ")
+      .withColumn("ER_CAM_F__CAM_PRS_IDE", when($"ER_CAM_F__CAM_PRS_IDE".isNull, "ABCD123").otherwise($"ER_CAM_F__CAM_PRS_IDE"))
+
+    val sources = {
+      val mco = spark.read.parquet("src/test/resources/test-input/MCO.parquet")
+      val dcir = df
+      new Sources(pmsiMco = Some(mco), pmsiMcoCE = Some(mcoCE), dcir = Some(dcir))
+    }
+    val expected = List(
+      DcirAct("Patient_01", "liberal", "ABCD123", makeTS(2006, 1, 15) ),
+      DcirAct("Patient_01", "liberal", "ABCD123", makeTS(2006, 1, 30)),
+      DcirAct("Patient_02", "liberal", "ABCD123", makeTS(2006, 1, 5)),
+      DcirAct("Patient_02", "liberal", "ABCD123", makeTS(2006, 1, 15)),
+      DcirAct("Patient_02", "liberal", "ABCD123", makeTS(2006, 1, 30)),
+      DcirAct("Patient_02", "liberal", "ABCD123", makeTS(2006, 1, 30))
+
+    ).toDS
+
+    // When
+    val result = new MedicalActs(config).extract(sources)
+    result.show()
+    // Then
+    assertDSs(result, expected)
+  }
+
 }

--- a/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/LiberalFracturesSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/LiberalFracturesSuite.scala
@@ -1,0 +1,33 @@
+package fr.polytechnique.cmap.cnam.study.fall
+
+import fr.polytechnique.cmap.cnam.SharedContext
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.util.functions.makeTS
+
+class LiberalFracturesSuite extends SharedContext {
+
+  "transform" should "transform events into outcomes" in {
+
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    //Given
+    val events = Seq(
+      MainDiagnosis("Pierre", "3", "S02.35", makeTS(2017, 7, 18)),
+      MainDiagnosis("Ben", "3", "S02.35", makeTS(2017, 7, 18)),
+      AssociatedDiagnosis("Sam", "3", "S02.35", makeTS(2015, 7, 18))
+    ).toDF.as[Event[MedicalAct]]
+    val expected = Seq(
+      Outcome("Pierre", "Liberal", makeTS(2017, 7, 18)),
+      Outcome("Ben", "Liberal", makeTS(2017, 7, 18)),
+      Outcome("Sam", "Liberal", makeTS(2015, 7, 18))
+    ).toDF.as[Event[Outcome]]
+
+    //When
+    val result = LiberalFractures.transform(events)
+
+    //Then
+    assertDSs(result, expected)
+
+  }
+
+}


### PR DESCRIPTION
This tasks consists on adding the liberal fractures to the current list of fractures.
The liberal fractures are all the fractures saved in DCIR but that do not have any corresspondant hospitalization (ER_ETE_F is null) and that  belong to a list of CCAM codes.
You can find more information in : https://datainitiative.atlassian.net/wiki/spaces/CFC/pages/61282101/General+fractures+Fall+study