### PR TITLE
HOTFIX Reorder and modify Main.

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/patients/DcirPatients.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/patients/DcirPatients.scala
@@ -94,7 +94,7 @@ private[patients] object DcirPatients {
       deathDateCol.as("deathDate")
     )
 
-    val persistedDcir = dcir.select(inputColumns:_*).persist()
+    val persistedDcir = dcir.select(inputColumns:_*)
 
     val birthYears: DataFrame = persistedDcir.findBirthYears
 
@@ -104,8 +104,6 @@ private[patients] object DcirPatients {
       .join(birthYears, "patientID")
       .estimateFields
       .as[Patient]
-
-    persistedDcir.unpersist()
     result
   }
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/patients/McoPatients.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/patients/McoPatients.scala
@@ -1,6 +1,5 @@
 package fr.polytechnique.cmap.cnam.etl.extractors.patients
 
-import org.apache.log4j.Logger
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame}
 import fr.polytechnique.cmap.cnam.util.functions._
@@ -31,7 +30,7 @@ private[patients] object McoPatients {
           countDistinct(col("deathDate")).as("count"),
           min(col("deathDate")).as("deathDate")
         ).cache()
-
+      /*
       val conflicts = result
         .filter(col("count") > 1)
         .select(col("patientID"))
@@ -43,7 +42,7 @@ private[patients] object McoPatients {
           conflicts.deep.mkString("\n") +
           "\nhave conflicting DEATH DATES in MCO." +
           "\nTaking Minimum Death Dates")
-
+    */
       result
     }
   }


### PR DESCRIPTION
This will avoid to materialize DCIR & MCO tables in memory, which will make the job more robust and speed up the processing time.