### PR TITLE
Simpler extraction for Drugs/MedicalActs

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/AnyEvent.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/AnyEvent.scala
@@ -1,5 +1,5 @@
 package fr.polytechnique.cmap.cnam.etl.events
 
-trait AnyEvent {
+trait AnyEvent extends Serializable {
   val category: EventCategory[AnyEvent]
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Classification.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Classification.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import org.apache.spark.sql.Row
 
 
-trait Classification extends AnyEvent with EventBuilder {
+trait Classification extends AnyEvent  {
 
   val category: EventCategory[Classification]
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Diagnosis.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Diagnosis.scala
@@ -3,7 +3,7 @@ package fr.polytechnique.cmap.cnam.etl.events
 import java.sql.Timestamp
 import org.apache.spark.sql.Row
 
-trait Diagnosis extends AnyEvent with EventBuilder {
+trait Diagnosis extends AnyEvent  {
 
   val category: EventCategory[Diagnosis]
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Drug.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Drug.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 
 object Drug extends Drug
 
-trait Drug extends Dispensation with EventBuilder {
+trait Drug extends Dispensation  {
 
   override val category: EventCategory[Drug] = "drug"
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Exposure.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Exposure.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 
 object Exposure extends Exposure
 
-trait Exposure extends AnyEvent with EventBuilder {
+trait Exposure extends AnyEvent  {
 
   val category: EventCategory[Exposure] = "exposure"
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/HospitalStay.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/HospitalStay.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import org.apache.spark.sql.Row
 import fr.polytechnique.cmap.cnam.etl.events.Event.Columns._
 
-trait HospitalStay extends AnyEvent with EventBuilder {
+trait HospitalStay extends AnyEvent  {
 
   override val category: EventCategory[HospitalStay] = "hospital_stay"
 
@@ -22,7 +22,7 @@ trait HospitalStay extends AnyEvent with EventBuilder {
     )
 
   def apply(patientID: String, hospitalID: String, start: Timestamp, end: Timestamp): Event[HospitalStay] =
-    apply(patientID, hospitalID, hospitalID, 0D, start, Some(end))
+    Event(patientID, category, hospitalID, hospitalID, 0D  , start, Some(end))
 }
 
 object HospitalStay extends HospitalStay

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/MedicalAct.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/MedicalAct.scala
@@ -3,7 +3,7 @@ package fr.polytechnique.cmap.cnam.etl.events
 import java.sql.Timestamp
 import org.apache.spark.sql.Row
 
-trait MedicalAct extends AnyEvent with EventBuilder {
+trait MedicalAct extends AnyEvent  {
 
   override val category: EventCategory[MedicalAct]
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Molecule.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Molecule.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 
 object Molecule extends Molecule
 
-trait Molecule extends Dispensation with EventBuilder {
+trait Molecule extends Dispensation  {
 
   override val category: EventCategory[Molecule] = "molecule"
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Outcome.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Outcome.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 
 object Outcome extends Outcome
 
-trait Outcome extends AnyEvent with EventBuilder {
+trait Outcome extends AnyEvent  {
 
   override val category: EventCategory[Outcome] = "outcome"
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/PractionnerClaimSpeciality.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/PractionnerClaimSpeciality.scala
@@ -3,7 +3,7 @@ package fr.polytechnique.cmap.cnam.etl.events
 import java.sql.Timestamp
 import org.apache.spark.sql.Row
 
-trait PractitionerClaimSpeciality extends AnyEvent with EventBuilder {
+trait PractitionerClaimSpeciality extends AnyEvent  {
 
   val category: EventCategory[PractitionerClaimSpeciality]
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Trackloss.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Trackloss.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 
 object Trackloss extends Trackloss
 
-trait Trackloss extends AnyEvent with EventBuilder {
+trait Trackloss extends AnyEvent  {
 
   val category: EventCategory[Trackloss] = "trackloss"
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/Columns.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/Columns.scala
@@ -1,0 +1,27 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import java.lang.reflect.Field;
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.col
+
+
+trait Columns extends Serializable {
+  def isEmpty(x: String) = x == null || x.trim.isEmpty
+  def validate(is : Boolean, f : Field, field_value : String) : String = {
+    f.setAccessible(is)
+    field_value
+  }
+  def getColumns : Array[String] = {
+    this.getClass.getDeclaredFields.map { f =>
+      val is = f.isAccessible
+      f.setAccessible(true)
+      val g = f.get(this)
+      val ret = g match {
+        case r: String => validate(is, f, r)
+        case _ =>
+          throw new RuntimeException("Only String type are handled by this class")
+      }
+      ret
+    }.filter(_.nonEmpty)
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/DCIRSourceExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/DCIRSourceExtract.scala
@@ -1,0 +1,67 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import java.sql.Timestamp
+import org.apache.spark.sql._
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.util.datetime.implicits._
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+import scala.util.Try
+
+class DCIRMedicalActEventExtractor(codes: Seq[String]) extends Serializable with DCIRSourceInfo {
+  def extract(r: Row): List[Event[MedicalAct]] = {
+    val idx = r.fieldIndex(PatientCols.CamCode)
+    codes.find(!r.isNullAt(idx) && r.getString(idx).startsWith(_))
+      .map {
+        code =>
+        val groupID = {
+          getGroupId(r) recover { case _: IllegalArgumentException => DcirAct.groupID.DcirAct }
+        }.get
+        DcirAct(
+          patientID = r.getAs[String](PatientCols.PatientID),
+          groupID = groupID,
+          code = code,
+          date = r.getAs[java.util.Date](PatientCols.Date).toTimestamp
+        )
+      }.toList
+  }
+
+  def getGroupId(r: Row): Try[String] = Try {
+    val sector = r.getAs[Double](PatientCols.Sector)
+    if (!r.isNullAt(r.fieldIndex(PatientCols.Sector)) && sector != 2) {
+      DcirAct.groupID.PublicAmbulatory
+    }
+    else {
+      if (r.isNullAt(r.fieldIndex(PatientCols.GHSCode))) {
+        DcirAct.groupID.Liberal
+      } else {
+        // Value is not at null, it is not liberal
+        lazy val ghs = r.getAs[Double](PatientCols.GHSCode)
+        lazy val institutionCode = r.getAs[Double](PatientCols.InstitutionCode)
+        // Check if it is a private ambulatory
+        if (ghs == 0 && PrivateInstitutionCodes.contains(institutionCode)) {
+          DcirAct.groupID.PrivateAmbulatory
+        }
+        else {
+          DcirAct.groupID.Unknown
+        }
+      }
+    }
+  }
+}
+
+class DCIRSourceExtractor(val sources : Sources, val extractors: List[DCIRMedicalActEventExtractor]) extends SourceExtractor with DCIRSourceInfo {
+
+  override def select() : DataFrame = {
+    sources.dcir.get
+  }
+
+  def extract[A <: AnyEvent](): Dataset[Event[A]] = {
+    val df = select()
+    import df.sqlContext.implicits._
+    df.flatMap {
+      r : Row =>
+      extractors.flatMap(extractor => extractor.extract(r)) }
+                .asInstanceOf[Dataset[Event[A]]]
+  }
+}
+

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/DCIRSourceTraits.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/DCIRSourceTraits.scala
@@ -1,0 +1,13 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+trait DCIRSourceInfo {
+  final lazy val PrivateInstitutionCodes = List(4, 5, 6, 7)
+  final object PatientCols extends Columns {
+    final val PatientID : String = "NUM_ENQ"
+    final val CamCode : String = "ER_CAM_F__CAM_PRS_IDE"
+    final val GHSCode : String = "ER_ETE_F__ETE_GHS_NUM"
+    final val InstitutionCode : String = "ER_ETE_F__ETE_TYP_COD"
+    final val Sector : String = "ER_ETE_F__PRS_PPU_SEC"
+    final val Date : String = "EXE_SOI_DTD"
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/EventRowExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/EventRowExtractor.scala
@@ -4,7 +4,6 @@ import java.sql.Timestamp
 import org.apache.spark.sql.Row
 
 trait EventRowExtractor {
-  self: ColumnNames =>
 
   def extractPatientId(r: Row): String
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/IMBSourceExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/IMBSourceExtract.scala
@@ -1,0 +1,41 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import java.sql.Date
+
+import org.apache.spark.sql._
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.util.datetime
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+
+trait IMBEventExtractor extends Serializable with IMBSourceInfo {
+  def extract(r: Row) : List[Event[AnyEvent]]
+}
+
+class IMBDiagnosisEventExtractor(codes: Seq[String]) extends IMBEventExtractor {
+  def extract(r: Row) : List[Event[AnyEvent]] = {
+    import datetime.implicits._
+    {
+      val encoding = r.getAs[String](ImbDiagnosesCols.Encoding)
+      val idx = r.fieldIndex(ImbDiagnosesCols.Code)
+      if (encoding != "CIM10" || r.isNullAt(idx))
+        None
+      codes.find(r.getString(idx).startsWith(_))
+    }.map{ code =>
+      ImbDiagnosis(
+        r.getAs[String](ImbDiagnosesCols.PatientID), code, r.getAs[Date](ImbDiagnosesCols.Date).toTimestamp)
+    }.toList
+  }
+}
+
+class IMBSourceExtractor(val sources : Sources, val extractors: List[IMBEventExtractor]) extends SourceExtractor with IMBSourceInfo {
+  override def select() : DataFrame = {
+    sources.irImb.get
+  }
+
+  def extract[A <: AnyEvent]() : Dataset[Event[A]] = {
+    val df = select()
+    import df.sqlContext.implicits._
+    df.flatMap { r : Row => extractors.flatMap(extractor => extractor.extract(r)) }
+    .asInstanceOf[Dataset[Event[A]]]
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/IMBSourceTraits.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/IMBSourceTraits.scala
@@ -1,0 +1,18 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions._
+
+trait IMBSourceInfo {
+
+  final object ImbDiagnosesCols {
+    final lazy val PatientID = "NUM_ENQ"
+    final lazy val Encoding = "MED_NCL_IDT"
+    final lazy val Code = "MED_MTF_COD"
+    final lazy val Date = "IMB_ALD_DTD"
+  }
+
+  implicit class StringToColumn(colName: String) {
+    def toCol: Column = col(colName)
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOCESourceExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOCESourceExtract.scala
@@ -1,0 +1,32 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.TimestampType
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+
+class McoCEMedicalActEventExtractor(sources: Sources, ccamCodes: Seq[String]) extends SourceExtractor with MCOCESourceInfo {
+  @transient final lazy val outputCols = List(
+    col(MCOCECols.PatientID).as("patientID"),
+    col(MCOCECols.CamCode).as("code"),
+    col(MCOCECols.Date).cast(TimestampType).as("eventDate"),
+    lit("ACE").as("groupID")
+  )
+  def correctCamCode(camCodes: Seq[String])(row: Row): Boolean = {
+    val camCode = row.getAs[String](MCOCECols.CamCode)
+    if (camCode != null) camCodes.map(camCode.startsWith).exists(identity) else false
+  }
+  override def select() : DataFrame = {
+    val mcoCE = sources.mcoCe.get
+    import mcoCE.sqlContext.implicits._
+    mcoCE.select(MCOCECols.getColumns.map(col): _*).filter(correctCamCode(ccamCodes) _)
+      .select(outputCols: _*)
+
+  }
+  override def extract[A <: AnyEvent]() : Dataset[Event[A]] = {
+    val df = select()
+    import df.sqlContext.implicits._
+    df.map(McoCEAct.fromRow(_)).asInstanceOf[Dataset[Event[A]]]
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOCESourceTraits.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOCESourceTraits.scala
@@ -1,0 +1,10 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+trait MCOCESourceInfo {
+
+  final object MCOCECols extends Columns {
+    final val PatientID : String = "NUM_ENQ"
+    final val CamCode : String = "MCO_FMSTC__CCAM_COD"
+    final val Date : String = "EXE_SOI_DTD"
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOSourceExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOSourceExtract.scala
@@ -1,0 +1,66 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import java.sql.Timestamp
+import org.apache.spark.sql._
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+
+abstract class MCOEventExtractor(column: String, codes: List[String]) extends Serializable with MCOSourceInfo {
+
+  def extract(r: Row, patientID: => String, groupID: => String, eventDate: => Timestamp): List[Event[AnyEvent]] = {
+    val idx = r.fieldIndex(column)
+    codes.find(!r.isNullAt(idx) && r.getString(idx).startsWith(_))
+      .map(c => get(patientID, groupID, c, eventDate))
+      .toList
+  }
+
+  def get(patientID: String, groupID: String, code: String, date: Timestamp): Event[AnyEvent]
+
+  def columns(): List[String] = MCOCols.getColumns.toList
+}
+
+class MCODiagnosisEventExtractor(column: String, codes: List[String], act: Diagnosis)
+  extends MCOEventExtractor(column, codes) {
+  def get(patientID: String, groupID: String, code: String, date: Timestamp): Event[Diagnosis] = {
+    act.apply(patientID, groupID, code, date)
+  }
+}
+
+class MCOMedicalActEventExtractor(column: String, codes: List[String], act: MedicalAct)
+  extends MCOEventExtractor(column, codes) {
+  def get(patientID: String, groupID: String, code: String, date: Timestamp): Event[MedicalAct] = {
+    act.apply(patientID, groupID, code, date)
+  }
+}
+
+class ClassificationEventExtractor(column: String, codes: List[String], act: Classification)
+  extends MCOEventExtractor(column, codes) {
+  def get(patientID: String, groupID: String, code: String, date: Timestamp): Event[Classification] = {
+    act.apply(patientID, groupID, code, date)
+  }
+
+  override def columns: List[String] = List.concat(MCOCols.getColumns.toList, List(MCOColsFull.GHM))
+}
+
+class MCOSourceExtractor(val sources : Sources, val extractors: List[MCOEventExtractor]) extends SourceExtractor with MCOSourceInfo {
+  val qcols = extractors.flatMap(extractor => extractor.columns()).distinct
+  override def select() : DataFrame = {
+    val mco = sources.mco.get
+    import mco.sqlContext.implicits._
+    mco.estimateStayStartTime.select(qcols.map(functions.col): _*)
+  }
+
+  override def extract[A <: AnyEvent]() : Dataset[Event[A]] = {
+    val df = select()
+    import df.sqlContext.implicits._
+    df.flatMap { r : Row =>
+        lazy val patientId = r.getAs[String](MCOCols.PatientID)
+        lazy val groupId   = r.getAs[String](MCOCols.EtaNum) + "_" +
+                             r.getAs[String](MCOCols.RsaNum) + "_" +
+                             r.getAs[Int](MCOCols.Year).toString
+        lazy val eventDate = r.getAs[Timestamp](MCOCols.EstimatedStayStart)
+        extractors.flatMap(extractor => extractor.extract(r, patientId, groupId, eventDate))
+    }.asInstanceOf[Dataset[Event[A]]]
+  }
+}
+

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOSourceTraits.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/MCOSourceTraits.scala
@@ -1,0 +1,58 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import fr.polytechnique.cmap.cnam.util.ColumnUtilities.parseTimestamp
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{LongType, TimestampType}
+import org.apache.spark.sql.{Column, DataFrame}
+
+trait MCOSourceInfo {
+
+  final object MCOCols extends Columns {
+    final val PatientID : String  = "NUM_ENQ"
+    final val DP : String  = "MCO_B__DGN_PAL"
+    final val DR : String = "MCO_B__DGN_REL"
+    final val DA : String = "MCO_D__ASS_DGN"
+    final val EtaNum : String  = "ETA_NUM"
+    final val RsaNum : String  = "RSA_NUM"
+    final val Year : String = "SOR_ANN"
+    final val EstimatedStayStart : String  = "estimated_start"
+    final val CCAM : String = "MCO_A__CDC_ACT"
+  }
+
+  final object MCOColsFull extends Columns  {
+    final lazy val GHM : String = "MCO_B__GRG_GHM"
+    final val StayEndMonth : String = "MCO_B__SOR_MOI"
+    final val StayEndYear : String = "MCO_B__SOR_ANN"
+    final val StayLength : String = "MCO_B__SEJ_NBJ"
+    final val StayStartDate : String = "ENT_DAT"
+    final val StayEndDate : String = "SOR_DAT"
+  }
+
+  implicit class StringToColumn(colName: String) {
+    def toCol: Column = col(colName)
+  }
+  implicit class McoDataFrame(df: DataFrame) {
+    final lazy val dayInMs = 24L * 60 * 60
+    final lazy val timeDelta: Column = coalesce(MCOColsFull.StayLength.toCol, lit(0)) * dayInMs
+    final lazy val estimate: Column = {
+      val endDate = parseTimestamp(MCOColsFull.StayEndDate.toCol, "ddMMyyyy")
+      (endDate.cast(LongType) - timeDelta).cast(TimestampType)
+    }
+    final lazy val roughEstimate: Column = (
+      unix_timestamp(
+        concat_ws("-", MCOColsFull.StayEndYear.toCol, MCOColsFull.StayEndMonth.toCol, lit("01 00:00:00"))
+      ).cast(LongType) - timeDelta
+    ).cast(TimestampType)
+    final lazy val givenDate: Column = parseTimestamp(MCOColsFull.StayStartDate.toCol, "ddMMyyyy")
+    /**
+      * Estimate the stay starting date according to the different versions of PMSI MCO
+      * Please note that in the case of early MCO (i.e. < 2009), the estimator is
+      * date(01/month/year) - number of days of the stay.
+      * This estimator is quite imprecise, and if one patient has several stays of the same
+      * length in one month, it results in duplicate events.
+      */
+    def estimateStayStartTime: DataFrame = {
+      df.withColumn(MCOCols.EstimatedStayStart, coalesce(givenDate, estimate, roughEstimate))
+    }
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/SourceExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/SourceExtract.scala
@@ -1,0 +1,13 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import java.sql.Timestamp
+import org.apache.spark.sql._
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+
+abstract class SourceExtractor extends Serializable {
+
+  def select() : DataFrame
+  def extract[A <: AnyEvent]() : Dataset[Event[A]]
+}
+

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/DcirMedicalActExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/DcirMedicalActExtractor.scala
@@ -10,7 +10,8 @@ object DcirMedicalActExtractor extends DcirExtractor[MedicalAct] {
 
   private final val PrivateInstitutionCodes = Set(4D, 5D, 6D, 7D)
   override val columnName: String = ColNames.CamCode
-  override val eventBuilder: EventBuilder = DcirAct
+  // override val eventBuilder: EventBuilder = DcirAct
+  override val category = DcirAct.category
 
   override def getInput(sources: Sources): DataFrame = sources.dcir.get.select(
     ColNames.PatientID, ColNames.CamCode, ColNames.Date,

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoActExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoActExtractor.scala
@@ -5,10 +5,10 @@ import fr.polytechnique.cmap.cnam.etl.extractors.mco.McoExtractor
 
 object McoCcamActExtractor extends McoExtractor[MedicalAct] {
   final override val columnName: String = ColNames.CCAM
-  override val eventBuilder: EventBuilder = McoCCAMAct
+  override val category = McoCCAMAct.category
 }
 
 object McoCimMedicalActExtractor extends McoExtractor[MedicalAct] {
   final override val columnName: String = ColNames.DP
-  override val eventBuilder: EventBuilder = McoCIM10Act
+  override val category = McoCIM10Act.category
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/classifications/GhmExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/classifications/GhmExtractor.scala
@@ -5,5 +5,5 @@ import fr.polytechnique.cmap.cnam.etl.extractors.mco.McoExtractor
 
 object GhmExtractor extends McoExtractor[Classification] {
   final override val columnName: String = ColNames.GHM
-  override val eventBuilder: EventBuilder = GHMClassification
+  override val category: String = GHMClassification.category
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
@@ -3,7 +3,7 @@ package fr.polytechnique.cmap.cnam.etl.extractors.dcir
 import java.sql.Timestamp
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
-import fr.polytechnique.cmap.cnam.etl.events.{AnyEvent, Event, EventBuilder}
+import fr.polytechnique.cmap.cnam.etl.events.{AnyEvent, Event}
 import fr.polytechnique.cmap.cnam.etl.extractors.{EventRowExtractor, Extractor}
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.util.datetime.implicits._
@@ -12,7 +12,7 @@ trait DcirExtractor[EventType <: AnyEvent] extends Extractor[EventType] with Dci
 
   val columnName: String
 
-  val eventBuilder: EventBuilder
+  val category: String
 
   def getInput(sources: Sources): DataFrame = sources.dcir.get.select(ColNames.all.map(col): _*)
 
@@ -28,7 +28,7 @@ trait DcirExtractor[EventType <: AnyEvent] extends Extractor[EventType] with Dci
     lazy val endDate = extractEnd(row)
     lazy val weight = extractWeight(row)
 
-    Seq(eventBuilder[EventType](patientId, groupId, code(row), weight, eventDate, endDate))
+    Seq(Event[EventType](patientId, category, groupId, code(row), weight, eventDate, endDate))
   }
 
   def code = (row: Row) => row.getAs[String](columnName)

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/McoDiagnosisExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/McoDiagnosisExtractor.scala
@@ -5,17 +5,17 @@ import fr.polytechnique.cmap.cnam.etl.extractors.mco.McoExtractor
 
 object MainDiagnosisExtractor extends McoExtractor[Diagnosis] {
   final override val columnName: String = ColNames.DP
-  override val eventBuilder: EventBuilder = MainDiagnosis
+  override val category: String  = MainDiagnosis.category
 }
 
 
 object AssociatedDiagnosisExtractor extends McoExtractor[Diagnosis] {
   final override val columnName: String = ColNames.DA
-  override val eventBuilder: EventBuilder = AssociatedDiagnosis
+  override val category: String  = AssociatedDiagnosis.category
 }
 
 
 object LinkedDiagnosisExtractor extends McoExtractor[Diagnosis] {
   final override val columnName: String = ColNames.DR
-  override val eventBuilder: EventBuilder = LinkedDiagnosis
+  override val category: String  = LinkedDiagnosis.category
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/drugs/DrugPurchaseDAO.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/drugs/DrugPurchaseDAO.scala
@@ -1,0 +1,12 @@
+package fr.polytechnique.cmap.cnam.etl.extractors.drugs
+
+import java.sql.Timestamp
+
+case class DrugPurchaseDAO(
+    patientID: String,
+    CIP13: String,
+    ATC5: String = "",
+    eventDate: Timestamp,
+    molecules: String = "",
+    conditioning: Int)
+

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/hospitalstays/HospitalStaysExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/hospitalstays/HospitalStaysExtractor.scala
@@ -9,7 +9,7 @@ import fr.polytechnique.cmap.cnam.etl.sources.Sources
 
 object HospitalStaysExtractor extends McoExtractor[HospitalStay] {
   override val columnName: String = ColNames.EndDate
-  override val eventBuilder: EventBuilder = HospitalStay
+  override val category: String  = HospitalStay.category
 
   override def extractEnd(r: Row): Option[Timestamp] = Some(new Timestamp(r.getAs[Date](ColNames.EndDate).getTime))
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/mco/McoExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/mco/McoExtractor.scala
@@ -11,7 +11,7 @@ trait McoExtractor[EventType <: AnyEvent] extends Extractor[EventType] with McoS
 
   val columnName: String
 
-  val eventBuilder: EventBuilder
+  val category: String
 
   def getInput(sources: Sources): DataFrame = sources.mco.get.select(ColNames.all.map(col): _*).estimateStayStartTime
 
@@ -27,7 +27,7 @@ trait McoExtractor[EventType <: AnyEvent] extends Extractor[EventType] with McoS
     lazy val endDate = extractEnd(row)
     lazy val weight = extractWeight(row)
 
-    Seq(eventBuilder[EventType](patientId, groupId, code(row), weight, eventDate, endDate))
+    Seq(Event[EventType](patientId, category, groupId, code(row), weight, eventDate, endDate))
   }
 
   def code = (row: Row) => row.getAs[String](columnName)

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/prestations/PractitionerClaimSpecialityExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/prestations/PractitionerClaimSpecialityExtractor.scala
@@ -8,7 +8,7 @@ import fr.polytechnique.cmap.cnam.etl.extractors.dcir.DcirExtractor
 
 object MedicalPractitionerClaimExtractor extends DcirExtractor[PractitionerClaimSpeciality] {
   override val columnName: String = ColNames.MSpe
-  override val eventBuilder: EventBuilder = MedicalPractitionerClaim
+  override val category: String = MedicalPractitionerClaim.category
 
   override def code: Row => String = (row: Row) => row.getAs[Integer](columnName).toString
 
@@ -25,7 +25,7 @@ object MedicalPractitionerClaimExtractor extends DcirExtractor[PractitionerClaim
 
 object NonMedicalPractitionerClaimExtractor extends DcirExtractor[PractitionerClaimSpeciality] {
   override val columnName: String = ColNames.NonMSpe
-  override val eventBuilder: EventBuilder = NonMedicalPractitionerClaim
+  override val category: String = NonMedicalPractitionerClaim.category
 
   override def code: Row => String = (row: Row) => row.getAs[Integer](columnName).toString
 

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/extractors/ActsExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/extractors/ActsExtractor.scala
@@ -1,20 +1,32 @@
 package fr.polytechnique.cmap.cnam.study.fall.extractors
 
 import org.apache.spark.sql.Dataset
-import fr.polytechnique.cmap.cnam.etl.events.{DcirAct, Event, MedicalAct}
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.extractors._
 import fr.polytechnique.cmap.cnam.etl.extractors.acts._
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.util.functions.unionDatasets
 
-class ActsExtractor(config: MedicalActsConfig) {
+class ActsExtractor(config: MedicalActsConfig) extends Serializable with MCOSourceInfo with MCOCESourceInfo with DCIRSourceInfo {
   def extract(sources: Sources): Dataset[Event[MedicalAct]] = {
-    val dcirMedicalAct = DcirMedicalActExtractor.extract(sources, config.dcirCodes.toSet)
-      .filter(act => act.groupID != DcirAct.groupID.Unknown) // filter out unknown source acts
-      .filter(act => act.groupID != DcirAct.groupID.PublicAmbulatory) //filter out public amb
-    val mcoCEMedicalActs = McoCeActExtractor.extract(sources, config.mcoCECodes.toSet)
-    val mcoMedicalActs = McoCcamActExtractor.extract(sources, config.mcoCCAMCodes.toSet)
+
+    val dcirMedicalAct_ : Dataset[Event[MedicalAct]]
+      = new DCIRSourceExtractor(sources/*.dcir.get*/, List(
+         new DCIRMedicalActEventExtractor(config.dcirCodes)))
+          .extract() // THIS FAILS AS A SINGLE STATEMENT ?!?
+    val dcirMedicalAct = dcirMedicalAct_
+        .filter(act => act.groupID != DcirAct.groupID.Unknown) // filter out unknown source acts
+        .filter(act => act.groupID != DcirAct.groupID.PublicAmbulatory) //filter out public amb
+
+    val mcoMedicalActs : Dataset[Event[MedicalAct]]
+      = new MCOSourceExtractor(sources, List(
+         new MCOMedicalActEventExtractor(MCOCols.CCAM, config.mcoCECodes, McoCCAMAct)))
+          .extract()
+
+    val mcoCEMedicalActs : Dataset[Event[MedicalAct]]
+      = new McoCEMedicalActEventExtractor(sources/*.mcoCe.get*/, config.mcoCECodes)
+         .extract()
 
     unionDatasets(dcirMedicalAct, mcoCEMedicalActs, mcoMedicalActs)
   }
-
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/extractors/DiagnosisExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/extractors/DiagnosisExtractor.scala
@@ -1,20 +1,20 @@
 package fr.polytechnique.cmap.cnam.study.fall.extractors
 
 import org.apache.spark.sql.Dataset
-import fr.polytechnique.cmap.cnam.etl.events.{Diagnosis, Event}
+import fr.polytechnique.cmap.cnam.etl.events.{Diagnosis, Event, _}
+import fr.polytechnique.cmap.cnam.etl.extractors._
 import fr.polytechnique.cmap.cnam.etl.extractors.diagnoses._
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
-import fr.polytechnique.cmap.cnam.util.functions.unionDatasets
 
-class DiagnosisExtractor(config: DiagnosesConfig) {
+class DiagnosisExtractor(config: DiagnosesConfig) extends Serializable with MCOSourceInfo {
 
   def extract(sources: Sources): Dataset[Event[Diagnosis]] = {
 
-    val mainDiag = MainDiagnosisExtractor.extract(sources, config.dpCodes.toSet)
-    val linkedDiag = LinkedDiagnosisExtractor.extract(sources, config.drCodes.toSet)
-    val dasDiag = AssociatedDiagnosisExtractor.extract(sources, config.daCodes.toSet)
-
-    unionDatasets(mainDiag, linkedDiag, dasDiag)
+    new MCOSourceExtractor(sources, List(
+        new MCODiagnosisEventExtractor(MCOCols.DP, config.dpCodes, MainDiagnosis),
+        new MCODiagnosisEventExtractor(MCOCols.DR, config.drCodes, LinkedDiagnosis),
+        new MCODiagnosisEventExtractor(MCOCols.DA, config.daCodes, AssociatedDiagnosis)
+      )
+    ).extract()
   }
-
 }

--- a/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/EventExtractorForAllTypesSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/EventExtractorForAllTypesSuite.scala
@@ -1,0 +1,164 @@
+package fr.polytechnique.cmap.cnam.etl.extractors
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import fr.polytechnique.cmap.cnam._
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.extractors.acts._, mco._
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+import fr.polytechnique.cmap.cnam.util.functions.makeTS
+
+class EventExtractorForAllTypesSuite extends SharedContext with MCOSourceInfo with DCIRSourceInfo {
+  ///* Handy for debugging datasets */
+  /*
+  val showString = classOf[org.apache.spark.sql.DataFrame].getDeclaredMethod("showString", classOf[Int], classOf[Int], classOf[Boolean])
+  showString.setAccessible(true)
+  */
+  // println(showString.invoke(df, 10.asInstanceOf[Object], 20.asInstanceOf[Object], false.asInstanceOf[Object]).asInstanceOf[String])
+
+  "DCIR.parquet extraction" should "DCIRSourceExtractor of DcirAct" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    val codes = List("AAAA", "CCCC")
+    val dcir = Seq(
+      ("Patient_A", "AAAA", makeTS(2010, 1, 1), None, None, None),
+      ("Patient_A", "BBBB", makeTS(2010, 2, 1), Some(1D), Some(0D), Some(1D)),
+      ("Patient_B", "CCCC", makeTS(2010, 3, 1), None, None, None),
+      ("Patient_B", "CCCC", makeTS(2010, 4, 1), Some(7D), Some(0D), Some(2D)),
+      ("Patient_C", "BBBB", makeTS(2010, 5, 1), Some(1D), Some(0D), Some(2D))
+    ).toDF(
+      PatientCols.PatientID, PatientCols.CamCode, PatientCols.Date,
+      PatientCols.InstitutionCode, PatientCols.GHSCode, PatientCols.Sector
+    )
+    val result : Dataset[Event[MedicalAct]] = new DCIRSourceExtractor(new Sources(dcir = Some(dcir)), List(new DCIRMedicalActEventExtractor(codes)))
+        .extract()
+    val expected : Dataset[Event[MedicalAct]] = Seq[Event[MedicalAct]](
+      DcirAct("Patient_A", DcirAct.groupID.Liberal, "AAAA", makeTS(2010, 1, 1)),
+      DcirAct("Patient_B", DcirAct.groupID.Liberal, "CCCC", makeTS(2010, 3, 1)),
+      DcirAct("Patient_B", DcirAct.groupID.PrivateAmbulatory, "CCCC", makeTS(2010, 4, 1))
+    ).toDS
+    assertDSs(expected, result)
+  }
+
+  "MCO.parquet extraction" should "MCOSourceExtractor of MedicalAct" in {
+    val sqlCtx = sqlContext; import sqlCtx.implicits._
+    val mco = spark.read.parquet("src/test/resources/test-input/MCO.parquet")
+    val result : Dataset[Event[MedicalAct]] = new MCOSourceExtractor(new Sources(mco = Some(mco)), List(
+      new MCOMedicalActEventExtractor(MCOCols.DP, List("C670", "C671"), McoCIM10Act),
+      new MCOMedicalActEventExtractor(MCOCols.CCAM, List("AAAA123"), McoCCAMAct)
+    )).extract()
+    val expected = Seq[Event[MedicalAct]](
+      McoCIM10Act("Patient_02", "10000123_10000543_2006", "C671", makeTS(2005, 12, 24)),
+      McoCIM10Act("Patient_02", "10000123_10000987_2006", "C670", makeTS(2005, 12, 29)),
+      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 29)),
+      McoCIM10Act("Patient_02", "10000123_20000123_2007", "C670", makeTS(2007, 1, 29)),
+      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 29)),
+      McoCIM10Act("Patient_02", "10000123_20000345_2007", "C671", makeTS(2007, 1, 29)),
+      McoCIM10Act("Patient_02", "10000123_30000546_2008", "C670", makeTS(2008, 3, 8)),
+      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 8)),
+      McoCIM10Act("Patient_02", "10000123_30000852_2008", "C671", makeTS(2008, 3, 15))
+    ).toDS
+    assertDSs(expected, result)
+  }
+
+  "MCO.parquet extraction" should "MCOSourceExtractor of Diagnosis" in {
+    val sqlCtx = sqlContext; import sqlCtx.implicits._
+    val mco: DataFrame = sqlContext.read.load("src/test/resources/test-input/MCO.parquet")
+    val result : Dataset[Event[Diagnosis]] = new MCOSourceExtractor(new Sources(mco = Some(mco)), List(
+      new MCODiagnosisEventExtractor(MCOCols.DP, List("C67"), MainDiagnosis),
+      new MCODiagnosisEventExtractor(MCOCols.DR, List("E05", "E08"), LinkedDiagnosis),
+      new MCODiagnosisEventExtractor(MCOCols.DA, List("C66"), AssociatedDiagnosis)))
+        .extract()
+    val expected = Seq[Event[Diagnosis]](
+      MainDiagnosis("Patient_02", "10000123_20000123_2007", "C67", makeTS(2007, 1, 29)),
+      LinkedDiagnosis("Patient_02", "10000123_20000123_2007", "E05", makeTS(2007, 1, 29)),
+      AssociatedDiagnosis("Patient_02", "10000123_20000123_2007", "C66", makeTS(2007, 1, 29)),
+      MainDiagnosis("Patient_02", "10000123_20000345_2007", "C67", makeTS(2007, 1, 29)),
+      MainDiagnosis("Patient_02", "10000123_10000987_2006", "C67", makeTS(2005, 12, 29)),
+      MainDiagnosis("Patient_02", "10000123_10000543_2006", "C67", makeTS(2005, 12, 24)),
+      LinkedDiagnosis("Patient_02", "10000123_10000543_2006", "E08", makeTS(2005, 12, 24)),
+      AssociatedDiagnosis("Patient_02", "10000123_10000543_2006", "C66", makeTS(2005, 12, 24)),
+      MainDiagnosis("Patient_02", "10000123_30000546_2008", "C67", makeTS(2008, 3, 8)),
+      MainDiagnosis("Patient_02", "10000123_30000852_2008", "C67", makeTS(2008, 3, 15))).toDS
+    assertDSs(expected, result)
+  }
+
+  "IR_IMB_R.parquet extraction" should "IMBSourceExtractor of ImbDiagnosis" in {
+    val sqlCtx = sqlContext; import sqlCtx.implicits._
+    val input = sqlContext.read.load("src/test/resources/test-input/IR_IMB_R.parquet")
+    val expected = Seq(ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13))).toDS
+    val output : Dataset[Event[Diagnosis]]  = new IMBSourceExtractor(new Sources(irImb = Some(input)),
+        List(new IMBDiagnosisEventExtractor(List("C67")))).extract()
+    assertDSs(expected, output)
+  }
+
+  "MCO.parquet extraction" should "MCOSourceExtractor of GHMClassification" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    val mco: DataFrame = sqlContext.read.load("src/test/resources/test-input/MCO.parquet")
+    // println(showString.invoke(mco, 10.asInstanceOf[Object], 20.asInstanceOf[Object], false.asInstanceOf[Object]).asInstanceOf[String])
+    val ghmCodes = List("12H50L")
+    val result : Dataset[Event[Classification]] =
+      new MCOSourceExtractor(new Sources(mco = Some(mco)), List(
+        new ClassificationEventExtractor(MCOColsFull.GHM, ghmCodes, GHMClassification))).extract()
+    val expected = Seq(
+      GHMClassification("Patient_02", "10000123_20000123_2007", "12H50L", makeTS(2007,1,29)),
+      GHMClassification("Patient_02", "10000123_10000987_2006", "12H50L", makeTS(2005,12,29)),
+      GHMClassification("Patient_02", "10000123_30000546_2008", "12H50L", makeTS(2008,3,8))
+    ).toDS
+    assertDSs(result, expected)
+  }
+
+  it should "return correct empty when given empty list" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    val mco: DataFrame = sqlContext.read.load("src/test/resources/test-input/MCO.parquet")
+    val ghmCodes = List()
+    val result : Dataset[Event[Classification]] =
+      new MCOSourceExtractor(new Sources(mco = Some(mco)), List(
+        new ClassificationEventExtractor(MCOColsFull.GHM, ghmCodes, GHMClassification)))
+          .extract()
+    val expected = sqlContext.sparkSession.emptyDataset[Event[Classification]]
+    assertDSs(result, expected)
+  }
+
+  "MCO.parquet extraction" should "match everything" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+    val mco: DataFrame = sqlContext.read.load("src/test/resources/test-input/MCO.parquet")
+    val result : Dataset[Event[AnyEvent]] =
+      new MCOSourceExtractor(new Sources(mco = Some(mco)), List(
+      new MCODiagnosisEventExtractor(MCOCols.DP, List("C67"), MainDiagnosis),
+      new MCODiagnosisEventExtractor(MCOCols.DR, List("E05", "E08"), LinkedDiagnosis),
+      new MCODiagnosisEventExtractor(MCOCols.DA, List("C66"), AssociatedDiagnosis),
+      new MCOMedicalActEventExtractor(MCOCols.DP, List("C670", "C671"), McoCIM10Act),
+      new MCOMedicalActEventExtractor(MCOCols.CCAM, List("AAAA123"), McoCCAMAct),
+      new ClassificationEventExtractor(MCOColsFull.GHM, List("12H50L"), GHMClassification)))
+        .extract()
+    val expected : Dataset[Event[AnyEvent]] = Seq(
+      MainDiagnosis("Patient_02", "10000123_20000123_2007", "C67", makeTS(2007, 1, 29)),
+      LinkedDiagnosis("Patient_02", "10000123_20000123_2007", "E05", makeTS(2007, 1, 29)),
+      AssociatedDiagnosis("Patient_02", "10000123_20000123_2007", "C66", makeTS(2007, 1, 29)),
+      MainDiagnosis("Patient_02", "10000123_20000345_2007", "C67", makeTS(2007, 1, 29)),
+      MainDiagnosis("Patient_02", "10000123_10000987_2006", "C67", makeTS(2005, 12, 29)),
+      MainDiagnosis("Patient_02", "10000123_10000543_2006", "C67", makeTS(2005, 12, 24)),
+      LinkedDiagnosis("Patient_02", "10000123_10000543_2006", "E08", makeTS(2005, 12, 24)),
+      AssociatedDiagnosis("Patient_02", "10000123_10000543_2006", "C66", makeTS(2005, 12, 24)),
+      MainDiagnosis("Patient_02", "10000123_30000546_2008", "C67", makeTS(2008, 3, 8)),
+      MainDiagnosis("Patient_02", "10000123_30000852_2008", "C67", makeTS(2008, 3, 15)),
+      McoCIM10Act("Patient_02", "10000123_10000543_2006", "C671", makeTS(2005, 12, 24)),
+      McoCIM10Act("Patient_02", "10000123_10000987_2006", "C670", makeTS(2005, 12, 29)),
+      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 29)),
+      McoCIM10Act("Patient_02", "10000123_20000123_2007", "C670", makeTS(2007, 1, 29)),
+      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 29)),
+      McoCIM10Act("Patient_02", "10000123_20000345_2007", "C671", makeTS(2007, 1, 29)),
+      McoCIM10Act("Patient_02", "10000123_30000546_2008", "C670", makeTS(2008, 3, 8)),
+      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 8)),
+      McoCIM10Act("Patient_02", "10000123_30000852_2008", "C671", makeTS(2008, 3, 15)),
+      GHMClassification("Patient_02", "10000123_20000123_2007", "12H50L", makeTS(2007,1,29)),
+      GHMClassification("Patient_02", "10000123_10000987_2006", "12H50L", makeTS(2005,12,29)),
+      GHMClassification("Patient_02", "10000123_30000546_2008", "12H50L", makeTS(2008,3,8))
+    ).toDS
+    assertDSs(result, expected)
+  }
+}


### PR DESCRIPTION
Deprecate existing MedicalActs/Diagnosis extractions and create new versions which allow multiple events to be found per source type (per select)