### PR TITLE
Serial extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.DS_Store
 
 # Tests
+save
 anyPath/
 output/
 metastore_db/
@@ -81,7 +82,7 @@ fabric.properties
 
 # *.iml
 # modules.xml
-# .idea/misc.xml 
+# .idea/misc.xml
 # *.ipr
 
 ### PDF generated stats ###

--- a/src/main/resources/config/fall/default.conf
+++ b/src/main/resources/config/fall/default.conf
@@ -40,3 +40,7 @@ cmap = ${root} {
 test = ${root} {
   include "paths/test.conf"   // Testing paths for the Pioglitazone study
 }
+
+save = ${root} {
+  include "paths/save.conf"   // Testing Python interop
+}

--- a/src/main/resources/config/fall/paths/save.conf
+++ b/src/main/resources/config/fall/paths/save.conf
@@ -1,0 +1,14 @@
+env_name = "save"
+
+input = {
+  dcir = "src/test/resources/test-input/DCIR.parquet"
+  mco = "src/test/resources/test-input/MCO.parquet"
+  mco_ce = "src/test/resources/test-input/MCO_CE.parquet"
+  ir_ben = "src/test/resources/test-input/IR_BEN_R.parquet"
+  ir_imb = "src/test/resources/test-input/IR_IMB_R.parquet"
+  ir_pha = "src/test/resources/test-input/IR_PHA_R_With_molecules.parquet"
+}
+
+output = {
+  root = "save/test/output"
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/config/Config.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/config/Config.scala
@@ -17,7 +17,5 @@ object Config {
         root.toString
       }
     }
-
   }
-
 }

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMain.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMain.scala
@@ -43,7 +43,6 @@ object FallMain extends Main with FractureCodes {
     dcir.unpersist()
     mco.unpersist()
 
-
     // Write Metadata
     val metadata = MainMetadata(this.getClass.getName, startTimestamp, new java.util.Date(), operationsMetadata.toList)
     val metadataJson: String = metadata.toJsonString()

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtract.scala
@@ -1,0 +1,147 @@
+package fr.polytechnique.cmap.cnam.study.fall
+
+import fr.polytechnique.cmap.cnam.Main
+import fr.polytechnique.cmap.cnam.etl.events.DcirAct
+import fr.polytechnique.cmap.cnam.etl.extractors.hospitalstays.HospitalStaysExtractor
+import fr.polytechnique.cmap.cnam.etl.extractors.patients.{Patients, PatientsConfig}
+import fr.polytechnique.cmap.cnam.etl.implicits
+import fr.polytechnique.cmap.cnam.etl.patients.Patient
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+import fr.polytechnique.cmap.cnam.study.fall.codes._
+import fr.polytechnique.cmap.cnam.study.fall.config.FallConfig
+import fr.polytechnique.cmap.cnam.study.fall.extractors._
+import fr.polytechnique.cmap.cnam.util.Path
+import fr.polytechnique.cmap.cnam.util.reporting._
+import org.apache.spark.sql.{Dataset, SQLContext}
+
+import scala.collection.mutable
+
+object FallMainExtract extends Main with FractureCodes {
+
+  override def appName: String = "fall study extract"
+
+  override def run(sqlContext: SQLContext, argsMap: Map[String, String]): Option[Dataset[_]] = {
+    import implicits.SourceReader
+    val fallConfig = FallConfig.load(argsMap("conf"), argsMap("env"))
+    val sources = Sources.sanitize(sqlContext.readSources(fallConfig.input))
+    val dcir = sources.dcir.get.repartition(4000).persist()
+    val mco = sources.mco.get.repartition(4000).persist()
+    val meta = mutable.HashMap[String, OperationMetadata]()
+    computeHospitalStays(meta, sources, fallConfig)
+    computeOutcomes(meta, sources, fallConfig)
+    computeExposures(meta, sources, fallConfig)
+    OperationMetadata.serialize(argsMap("meta_bin"), meta)
+    dcir.unpersist()
+    mco.unpersist()
+    None
+  }
+
+  def computeHospitalStays(meta: mutable.HashMap[String, OperationMetadata], sources: Sources, fallConfig: FallConfig):
+  mutable.HashMap[String, OperationMetadata] = {
+
+    if (fallConfig.runParameters.hospitalStays) {
+      val hospitalStays = HospitalStaysExtractor.extract(sources, Set.empty).cache()
+      meta += {
+        "extract_hospital_stays" ->
+          OperationReporter
+            .reportAsDataSet(
+              "extract_hospital_stays",
+              List("MCO"),
+              OperationTypes.HospitalStays,
+              hospitalStays,
+              Path(fallConfig.output.outputSavePath),
+              fallConfig.output.saveMode
+            )
+      }
+    }
+    meta
+  }
+
+  def computeExposures(meta: mutable.HashMap[String, OperationMetadata], sources: Sources, fallConfig: FallConfig):
+  mutable.HashMap[String, OperationMetadata] = {
+
+    if (fallConfig.runParameters.drugPurchases) {
+      val drugPurchases = new DrugsExtractor(fallConfig.drugs).extract(sources).cache()
+      meta += {
+        "drug_purchases" ->
+          OperationReporter
+            .reportAsDataSet(
+              "drug_purchases",
+              List("DCIR"),
+              OperationTypes.Dispensations,
+              drugPurchases,
+              Path(fallConfig.output.outputSavePath),
+              fallConfig.output.saveMode
+            )
+      }
+    }
+
+    if (fallConfig.runParameters.patients) {
+      val patients: Dataset[Patient] = new Patients(PatientsConfig(fallConfig.base.studyStart)).extract(sources).cache()
+      meta += {
+        "extract_patients" ->
+          OperationReporter
+            .reportAsDataSet(
+              "extract_patients",
+              List("DCIR", "MCO", "IR_BEN_R", "MCO_CE"),
+              OperationTypes.Patients,
+              patients,
+              Path(fallConfig.output.outputSavePath),
+              fallConfig.output.saveMode
+            )
+      }
+    }
+    meta
+  }
+
+  def computeOutcomes(meta: mutable.HashMap[String, OperationMetadata], sources: Sources, fallConfig: FallConfig):
+  mutable.HashMap[String, OperationMetadata] = {
+
+    if (fallConfig.runParameters.diagnoses) {
+      logger.info("diagnoses")
+      val diagnoses = new DiagnosisExtractor(fallConfig.diagnoses).extract(sources).persist()
+      val diagnoses_report = OperationReporter.reportAsDataSet(
+        "diagnoses",
+        List("MCO", "IR_IMB_R"),
+        OperationTypes.Diagnosis,
+        diagnoses,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        diagnoses_report.name -> diagnoses_report
+      }
+    }
+
+    if (fallConfig.runParameters.acts) {
+      logger.info("Medical Acts")
+      val acts = new ActsExtractor(fallConfig.medicalActs).extract(sources).persist()
+      val acts_report = OperationReporter.reportAsDataSet(
+        "acts",
+        List("DCIR", "MCO", "MCO_CE"),
+        OperationTypes.MedicalActs,
+        acts,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        acts_report.name -> acts_report
+      }
+      logger.info("Liberal Medical Acts")
+      val liberalActs = acts
+        .filter(act => act.groupID == DcirAct.groupID.Liberal && !CCAMExceptions.contains(act.value)).persist()
+      val liberal_acts_report = OperationReporter.reportAsDataSet(
+        "liberal_acts",
+        List("acts"),
+        OperationTypes.MedicalActs,
+        liberalActs,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        liberal_acts_report.name -> liberal_acts_report
+      }
+    }
+    meta
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainTransform.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainTransform.scala
@@ -1,0 +1,143 @@
+package fr.polytechnique.cmap.cnam.study.fall
+
+import fr.polytechnique.cmap.cnam.Main
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.filters.PatientFilters
+import fr.polytechnique.cmap.cnam.etl.patients.Patient
+import fr.polytechnique.cmap.cnam.etl.transformers.exposures.ExposuresTransformer
+import fr.polytechnique.cmap.cnam.study.fall.codes._
+import fr.polytechnique.cmap.cnam.study.fall.config.FallConfig
+import fr.polytechnique.cmap.cnam.study.fall.follow_up.FallStudyFollowUps
+import fr.polytechnique.cmap.cnam.study.fall.fractures.FracturesTransformer
+import fr.polytechnique.cmap.cnam.util.Path
+import fr.polytechnique.cmap.cnam.util.datetime.implicits._
+import fr.polytechnique.cmap.cnam.util.reporting._
+import org.apache.spark.sql.{Dataset, SQLContext, SparkSession}
+
+import scala.collection.mutable
+
+object FallMainTransform extends Main with FractureCodes {
+
+  override def appName: String = "fall study transform"
+
+  override def run(sqlContext: SQLContext, argsMap: Map[String, String]): Option[Dataset[_]] = {
+    val format = new java.text.SimpleDateFormat("yyyy_MM_dd_HH_mm_ss")
+    val startTimestamp = new java.util.Date()
+    val fallConfig = FallConfig.load(argsMap("conf"), argsMap("env"))
+    val operationsMetadata = OperationMetadata.deserialize(argsMap("meta_bin"))
+    transformExposures(operationsMetadata, fallConfig)
+    transformOutcomes(operationsMetadata, fallConfig)
+
+    // Write Metadata
+    val metadata = MainMetadata(this.getClass.getName, startTimestamp, new java.util.Date(), operationsMetadata.values.toList)
+    val metadataJson: String = metadata.toJsonString()
+
+    OperationReporter
+      .writeMetaData(metadataJson, "metadata_fall_" + format.format(startTimestamp) + ".json", argsMap("env"))
+    None
+  }
+
+  def transformExposures(meta: mutable.Map[String, OperationMetadata], fallConfig: FallConfig):
+      mutable.Map[String, OperationMetadata] = {
+
+    val spark = SparkSession.builder.getOrCreate()
+    import spark.implicits._
+    val patients: Dataset[Patient]
+    = spark.read.parquet(meta.get("extract_patients").get.outputPath)
+      .as[Patient].cache()
+    val drugPurchases: Dataset[Event[Drug]]
+    = spark.read.parquet(meta.get("drug_purchases").get.outputPath)
+      .as[Event[Drug]].cache()
+
+    if (fallConfig.runParameters.startGapPatients) {
+      import PatientFilters._
+      val filteredPatients: Dataset[Patient] = patients
+        .filterNoStartGap(drugPurchases, fallConfig.base.studyStart, fallConfig.patients.startGapInMonths)
+        .cache()
+      val filteredPatientsReport = OperationReporter.reportAsDataSet(
+        "filter_patients",
+        List("drug_purchases", "extract_patients"),
+        OperationTypes.Patients,
+        filteredPatients,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        filteredPatientsReport.name -> filteredPatientsReport
+      }
+    }
+
+    if (fallConfig.runParameters.exposures) {
+      val exposures = {
+        val definition = fallConfig.exposures
+        val patientsWithFollowUp = FallStudyFollowUps.transform(
+          patients,
+          fallConfig.base.studyStart,
+          fallConfig.base.studyEnd,
+          fallConfig.patients.followupStartDelay
+        )
+        import patientsWithFollowUp.sparkSession.sqlContext.implicits._
+        val followUps = patientsWithFollowUp.map(_._2).cache()
+        val followUpReport = OperationReporter.reportAsDataSet(
+          "follow_up",
+          List("extract_patients"),
+          OperationTypes.AnyEvents,
+          followUps,
+          Path(fallConfig.output.outputSavePath),
+          fallConfig.output.saveMode
+        )
+        meta += {
+          followUpReport.name -> followUpReport
+        }
+        new ExposuresTransformer(definition).transform(patientsWithFollowUp, drugPurchases).cache()
+      }
+      val exposuresReport = OperationReporter.reportAsDataSet(
+        "exposures",
+        List("drug_purchases"),
+        OperationTypes.Exposures,
+        exposures,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        exposuresReport.name -> exposuresReport
+      }
+    }
+    meta
+  }
+
+  def transformOutcomes(meta: mutable.Map[String, OperationMetadata], fallConfig: FallConfig):
+      mutable.Map[String, OperationMetadata] = {
+
+    val spark = SparkSession.builder.getOrCreate()
+    import spark.implicits._
+
+    val diagnoses = spark.read.parquet(meta("diagnoses").outputPath)
+      .as[Event[Diagnosis]]
+
+    val acts = spark.read.parquet(meta("acts").outputPath)
+      .as[Event[MedicalAct]]
+
+    val liberalActs = spark.read.parquet(meta("liberal_acts").outputPath)
+      .as[Event[MedicalAct]]
+
+    if (fallConfig.runParameters.outcomes) {
+      logger.info("Fractures")
+      val fractures: Dataset[Event[Outcome]] = new FracturesTransformer(fallConfig)
+        .transform(liberalActs, acts, diagnoses)
+      val fractures_report = OperationReporter.reportAsDataSet(
+        "fractures",
+        List("acts"),
+        OperationTypes.Outcomes,
+        fractures,
+        Path(fallConfig.output.outputSavePath),
+        fallConfig.output.saveMode
+      )
+      meta += {
+        fractures_report.name -> fractures_report
+      }
+    }
+    meta
+  }
+}
+

--- a/src/main/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationMetadata.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationMetadata.scala
@@ -1,5 +1,8 @@
 package fr.polytechnique.cmap.cnam.util.reporting
 
+import java.io._
+import scala.collection._
+
 /**
   * Represents the reporting metadata for a single operation.
   * An operation can be any method that touches a DataFrame, including but not limited to: readers,
@@ -9,7 +12,40 @@ case class OperationMetadata(
   name: String,
   inputs: List[String],
   outputType: OperationType,
-  outputPath: Option[String],
-  populationPath: Option[String])
+  outputPath: String = "",
+  populationPath: String = "")
   extends JsonSerializable
 
+object OperationMetadata {
+
+  // REASON: https://stackoverflow.com/a/22375260/795574
+  def deserialize(file : String) : mutable.Map[String, OperationMetadata] = {
+    val ois = new ObjectInputStream(new FileInputStream(file)) {
+      override def resolveClass(desc: java.io.ObjectStreamClass): Class[_] = {
+        try {
+          Class.forName(desc.getName, false, getClass.getClassLoader)
+        }
+        catch {
+          case ex: ClassNotFoundException => super.resolveClass(desc)
+        }
+      }
+    }
+    val meta : java.util.Map[String, OperationMetadata]
+      = ois.readObject.asInstanceOf[java.util.Map[String, OperationMetadata]]
+    ois.close
+    JavaConversions.mapAsScalaMap[String, OperationMetadata](meta)
+  }
+
+  // Scala JavaConversions has issues with serialization
+  def scalaToJavaHashMapConverter(scalaMap: mutable.HashMap[String, OperationMetadata]) = {
+    val javaHashMap = new java.util.HashMap[String, OperationMetadata]()
+    scalaMap.foreach(entry => javaHashMap.put(entry._1, entry._2))
+    javaHashMap
+  }
+
+  def serialize(file : String, meta : mutable.HashMap[String, OperationMetadata]) = {
+    val oos = new ObjectOutputStream(new FileOutputStream(file))
+    oos.writeObject(scalaToJavaHashMapConverter(meta))
+    oos.close
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationReporter.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationReporter.scala
@@ -1,10 +1,11 @@
 package fr.polytechnique.cmap.cnam.util.reporting
 
 import java.io.PrintWriter
-import org.apache.log4j.Logger
-import org.apache.spark.sql.DataFrame
+
 import fr.polytechnique.cmap.cnam.util.Path
 import fr.polytechnique.cmap.cnam.util.RichDataFrame._
+import org.apache.log4j.Logger
+import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
 
 /**
   * Singleton responsible for reporting an operation execution.
@@ -33,33 +34,33 @@ object OperationReporter {
     * @return an instance of OperationMetadata
     */
   def report(
-    operationName: String,
-    operationInputs: List[String],
-    outputType: OperationType,
-    data: DataFrame,
-    basePath: Path,
-    saveMode: String = "errorIfExists",
-    patientIdColName: String = "patientID"): OperationMetadata = {
-
-    logger.info(s"""=> Reporting operation "$operationName" of output type "$outputType"""")
+              operationName: String,
+              operationInputs: List[String],
+              outputType: OperationType,
+              data: DataFrame,
+              basePath: Path,
+              saveMode: String = "errorIfExists",
+              patientIdColName: String = "patientID"): OperationMetadata = {
 
     val dataPath: Path = Path(basePath, operationName, "data")
-    val patientsPath: Path = Path(basePath, operationName, "patients")
+    val dataPathStr = dataPath.toString
+    logger.info(s"""=> Reporting operation "$operationName" of output type "$outputType" to "$dataPathStr"""")
 
-    val baseMetadata = OperationMetadata(operationName, operationInputs, outputType, None, None)
+    val patientsPath: Path = Path(basePath, operationName, "patients")
+    val baseMetadata = OperationMetadata(operationName, operationInputs, outputType)
 
     outputType match {
       case OperationTypes.Patients =>
         data.writeParquet(dataPath.toString, saveMode)
         baseMetadata.copy(
-          outputPath = Some(dataPath.toString)
+          outputPath = dataPath.toString
         )
 
       case OperationTypes.Sources =>
         val patients = data.select(patientIdColName).distinct
         patients.writeParquet(patientsPath.toString, saveMode)
         baseMetadata.copy(
-          populationPath = Some(patientsPath.toString)
+          populationPath = patientsPath.toString
         )
 
       case _ =>
@@ -67,8 +68,41 @@ object OperationReporter {
         val patients = data.select(patientIdColName).distinct
         patients.writeParquet(patientsPath.toString, saveMode)
         baseMetadata.copy(
-          outputPath = Some(dataPath.toString),
-          populationPath = Some(patientsPath.toString)
+          outputPath = dataPath.toString,
+          populationPath = patientsPath.toString
+        )
+    }
+  }
+
+  def reportAsDataSet[A](
+                          operationName: String,
+                          operationInputs: List[String],
+                          outputType: OperationType,
+                          data: Dataset[A],
+                          basePath: Path,
+                          saveMode: String = "errorIfExists",
+                          patientIdColName: String = "patientID"): OperationMetadata = {
+
+    val dataPath: Path = Path(basePath, operationName, "data")
+    val dataPathStr = dataPath.toString
+    logger.info(s"""=> Reporting operation "$operationName" of output type "$outputType" to "$dataPathStr"""")
+
+    val patientsPath: Path = Path(basePath, operationName, "patients")
+    val baseMetadata = OperationMetadata(operationName, operationInputs, outputType)
+
+    outputType match {
+      case OperationTypes.Patients =>
+        data.write.mode(saveModeFrom(saveMode)).parquet(dataPath.toString)
+        baseMetadata.copy(
+          outputPath = dataPath.toString
+        )
+      case _ =>
+        data.write.mode(saveModeFrom(saveMode)).parquet(dataPath.toString)
+        val patients = data.select(patientIdColName).distinct
+        patients.write.mode(saveMode).parquet(patientsPath.toString)
+        baseMetadata.copy(
+          outputPath = dataPath.toString,
+          populationPath = patientsPath.toString
         )
     }
   }
@@ -89,4 +123,10 @@ object OperationReporter {
     }
   }
 
+  private def saveModeFrom(mode: String): SaveMode = mode match {
+    case "overwrite" => SaveMode.Overwrite
+    case "append" => SaveMode.Append
+    case "errorIfExists" => SaveMode.ErrorIfExists
+    case "withTimestamp" => SaveMode.Overwrite
+  }
 }

--- a/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtractorTransformSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtractorTransformSuite.scala
@@ -1,0 +1,41 @@
+package fr.polytechnique.cmap.cnam.study.fall
+
+import fr.polytechnique.cmap.cnam.SharedContext
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.etl.extractors.patients.{Patients, PatientsConfig}
+import fr.polytechnique.cmap.cnam.etl.implicits
+import fr.polytechnique.cmap.cnam.etl.patients.Patient
+import fr.polytechnique.cmap.cnam.etl.sources.Sources
+import fr.polytechnique.cmap.cnam.study.fall.config.FallConfig
+import fr.polytechnique.cmap.cnam.study.fall.extractors._
+import fr.polytechnique.cmap.cnam.util.reporting._
+import org.apache.spark.sql.{Encoders, SparkSession}
+
+class FallMainExtractorTransformSuite extends SharedContext {
+
+  "ExtractionSerialization" should "deserialize and work" in {
+    val sqlCtx = sqlContext
+    val spark = SparkSession.builder.getOrCreate()
+    import implicits.SourceReader
+    val params = Map(
+      "conf" -> "/src/main/resources/config/fall/default.conf",
+      "env" -> "test", // change "test" to "save" for python interop
+      "meta_bin" -> "target/test/output/meta_data.bin"
+    )
+    FallMainExtract.run(sqlCtx, params)
+    FallMainTransform.run(sqlCtx, params)
+
+    val fallConfig = FallConfig.load(params("conf"), params("env"))
+    val meta = OperationMetadata.deserialize(params("meta_bin"))
+    val sources = Sources.sanitize(sqlContext.readSources(fallConfig.input))
+    assertDSs(new DiagnosisExtractor(fallConfig.diagnoses).extract(sources),
+      spark.read.parquet(meta.get("diagnoses").get.outputPath)
+        .as(Encoders.bean(classOf[Event[Diagnosis]])))
+    assertDSs(new ActsExtractor(fallConfig.medicalActs).extract(sources),
+      spark.read.parquet(meta.get("acts").get.outputPath)
+        .as(Encoders.bean(classOf[Event[MedicalAct]])))
+    assertDSs(new Patients(PatientsConfig(fallConfig.base.studyStart)).extract(sources),
+      spark.read.parquet(meta.get("extract_patients").get.outputPath)
+        .as(Encoders.bean(classOf[Patient])))
+  }
+}

--- a/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainSuite.scala
@@ -4,6 +4,7 @@ import fr.polytechnique.cmap.cnam.SharedContext
 import fr.polytechnique.cmap.cnam.etl.implicits
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.study.fall.config.FallConfig
+import org.apache.spark.sql.functions.lit
 
 class FallMainSuite extends SharedContext {
 
@@ -49,7 +50,7 @@ class FallMainSuite extends SharedContext {
 
     //When
     val result = FallMain.computeExposures(sources, fallConfig)
-    val resultOutputPaths = result.map(_.outputPath.getOrElse("")).toList
+    val resultOutputPaths = result.map(_.outputPath).toList
     val resultOutputTypes = result.map(_.outputType.toString).toList
 
     //Then
@@ -72,7 +73,7 @@ class FallMainSuite extends SharedContext {
 
     //When
     val result = FallMain.computeOutcomes(sources, fallConfig)
-    val resultOutputPaths = result.map(_.outputPath.getOrElse("")).toList
+    val resultOutputPaths = result.map(_.outputPath).toList
     val resultOutputTypes = result.map(_.outputType.toString).toList
 
     //Then
@@ -91,13 +92,11 @@ class FallMainSuite extends SharedContext {
 
     //When
     val result = FallMain.computeHospitalStays(sources, fallConfig)
-    val resultOutputPaths = result.map(_.outputPath.getOrElse("")).toList
+    val resultOutputPaths = result.map(_.outputPath).toList
     val resultOutputTypes = result.map(_.outputType.toString).toList
 
     //Then
     assert(expectedOutputPaths.forall(resultOutputPaths.contains))
     assert(expectedOutputTypes.forall(resultOutputTypes.contains))
   }
-
-
 }

--- a/src/test/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationReporterSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/util/reporting/OperationReporterSuite.scala
@@ -19,8 +19,8 @@ class OperationReporterSuite extends SharedContext {
     val expected = OperationMetadata(
       "test", List("input"),
       OperationTypes.AnyEvents,
-      Some(Path(path, "test", "data").toString),
-      Some(Path(path, "test", "patients").toString)
+      Path(path, "test", "data").toString,
+      Path(path, "test", "patients").toString
     )
 
     // When
@@ -43,15 +43,15 @@ class OperationReporterSuite extends SharedContext {
 
     // When
     var meta = OperationReporter.report("test", List("input"), OperationTypes.AnyEvents, data.toDF, path, "overwrite")
-    val result = spark.read.parquet(meta.outputPath.get)
+    val result = spark.read.parquet(meta.outputPath)
     val exception = intercept[Exception] {
       OperationReporter.report("test", List("input"), OperationTypes.AnyEvents, data.toDF, path)
     }
     meta = OperationReporter.report("test", List("input"), OperationTypes.AnyEvents, data.toDF, path, "append")
-    val resultAppend = spark.read.parquet(meta.outputPath.get)
+    val resultAppend = spark.read.parquet(meta.outputPath)
     meta = OperationReporter
       .report("test", List("input"), OperationTypes.AnyEvents, data.toDF, pathWithTimestamp, "withTimestamp")
-    val resultWithTimestamp = spark.read.parquet(meta.outputPath.get)
+    val resultWithTimestamp = spark.read.parquet(meta.outputPath)
 
 
     // Then
@@ -87,8 +87,7 @@ class OperationReporterSuite extends SharedContext {
     val expectedMetadata = OperationMetadata(
       "test", List("input"),
       OperationTypes.Patients,
-      Some(Path(basePath, "test", "data").toString),
-      None
+      Path(basePath, "test", "data").toString
     )
     val expectedData = Seq(("Patient_A", 1), ("Patient_B", 2)).toDF("patientID", "other_col")
 
@@ -111,8 +110,8 @@ class OperationReporterSuite extends SharedContext {
     val expectedMetadata = OperationMetadata(
       "test", List("input"),
       OperationTypes.Sources,
-      None,
-      Some(Path(basePath, "test", "patients").toString)
+      "",
+      Path(basePath, "test", "patients").toString
     )
     val expectedPatients = Seq("Patient_A", "Patient_B").toDF("patientID")
 


### PR DESCRIPTION
Serialize Extractions as Java.HashMap for python interop
Deserialize Extractions to Scala mutable.HashMap
Python interop looks like

```
import javaobj               # requires ```pip install javaobj-py3```
import pyarrow.parquet as pq # requires ```pip install pyarrow```

with open("meta_data.bin", "rb") as fd:
    jobj = fd.read()

meta = javaobj.loads(jobj)
print(meta["extract_patients"].name)
print(pq.read_table(meta["diagnoses"].outputPath))
print(pq.read_table(meta["acts"].outputPath))
print(pq.read_table(meta["extract_patients"].outputPath))
```