### PR TITLE
CNAM-401: Refine starting date of MCO Medical Acts

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoActExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoActExtractor.scala
@@ -1,11 +1,24 @@
 package fr.polytechnique.cmap.cnam.etl.extractors.acts
 
+import java.sql.Timestamp
+import me.danielpes.spark.datetime.Period
+import me.danielpes.spark.datetime.implicits.DateImplicits
+import org.apache.spark.sql.Row
 import fr.polytechnique.cmap.cnam.etl.events._
 import fr.polytechnique.cmap.cnam.etl.extractors.mco.McoExtractor
 
 object McoCcamActExtractor extends McoExtractor[MedicalAct] {
   final override val columnName: String = ColNames.CCAM
   override val eventBuilder: EventBuilder = McoCCAMAct
+
+  override def extractStart(r: Row): Timestamp = {
+    (DateImplicits(r.getAs[Timestamp](NewColumns.EstimatedStayStart)) + Period(days = getDateOffset(r))).get
+  }
+
+  def getDateOffset(r: Row): Int = r.getAs[String](ColNames.CCAMDelayDate) match {
+    case null => 0
+    case value: String => value.toInt
+  }
 }
 
 object McoCimMedicalActExtractor extends McoExtractor[MedicalAct] {

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
@@ -19,8 +19,7 @@ trait DcirExtractor[EventType <: AnyEvent] extends Extractor[EventType] with Dci
   def isInStudy(codes: Set[String])
     (row: Row): Boolean = codes.exists(code(row).startsWith(_))
 
-  def isInExtractorScope(row: Row): Boolean = !row.isNullAt(row.fieldIndex(columnName)) && !row
-    .isNullAt(row.fieldIndex(ColNames.Date))
+  def isInExtractorScope(row: Row): Boolean = !row.isNullAt(row.fieldIndex(columnName))
 
   def builder(row: Row): Seq[Event[EventType]] = {
     lazy val patientId = extractPatientId(row)

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/dcir/DcirExtractor.scala
@@ -19,7 +19,8 @@ trait DcirExtractor[EventType <: AnyEvent] extends Extractor[EventType] with Dci
   def isInStudy(codes: Set[String])
     (row: Row): Boolean = codes.exists(code(row).startsWith(_))
 
-  def isInExtractorScope(row: Row): Boolean = !row.isNullAt(row.fieldIndex(columnName))
+  def isInExtractorScope(row: Row): Boolean = !row.isNullAt(row.fieldIndex(columnName)) && !row
+    .isNullAt(row.fieldIndex(ColNames.Date))
 
   def builder(row: Row): Seq[Event[EventType]] = {
     lazy val patientId = extractPatientId(row)

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/mco/McoSource.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/mco/McoSource.scala
@@ -14,6 +14,7 @@ trait McoSource extends ColumnNames {
     val DR: ColName = "MCO_B__DGN_REL"
     val DA: ColName = "MCO_D__ASS_DGN"
     val CCAM: ColName = "MCO_A__CDC_ACT"
+    val CCAMDelayDate: ColName = "MCO_A__ENT_DAT_DEL"
     val GHM: ColName = "MCO_B__GRG_GHM"
     val EtaNum: ColName = "ETA_NUM"
     val RsaNum: ColName = "RSA_NUM"
@@ -26,7 +27,7 @@ trait McoSource extends ColumnNames {
     val StartDate: ColName = "EXE_SOI_DTD"
     val EndDate: ColName = "EXE_SOI_DTF"
     val all = List(
-      PatientID, DP, DR, DA, CCAM, GHM, EtaNum, RsaNum, Year, StayEndMonth, StayEndYear, StayLength,
+      PatientID, DP, DR, DA, CCAM, CCAMDelayDate, GHM, EtaNum, RsaNum, Year, StayEndMonth, StayEndYear, StayLength,
       StayStartDate, StayEndDate, StartDate, EndDate
     )
     val hospitalStayPart = List(

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/bulk/BulkMain.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/bulk/BulkMain.scala
@@ -32,6 +32,21 @@ object BulkMain extends Main {
 
     val operationsMetadata = mutable.Buffer[OperationMetadata]()
 
+    val ccamMedicalAct = McoCcamActExtractor.extract(sources, Set.empty).cache()
+
+    operationsMetadata += {
+      OperationReporter.report(
+        "CCAM-Medical-Acts",
+        List("MCO"),
+        OperationTypes.MedicalActs,
+        ccamMedicalAct.toDF,
+        Path(bulkConfig.output.outputSavePath),
+        bulkConfig.output.saveMode
+      )
+    }
+
+    ccamMedicalAct.unpersist()
+
     val drugs = new DrugExtractor(bulkConfig.drugs).extract(sources, Set.empty).cache()
 
     operationsMetadata += {
@@ -90,22 +105,6 @@ object BulkMain extends Main {
     }
 
     cimMedicalAct.unpersist()
-
-
-    val ccamMedicalAct = McoCcamActExtractor.extract(sources, Set.empty).cache()
-
-    operationsMetadata += {
-      OperationReporter.report(
-        "CCAM-Medical-Acts",
-        List("MCO"),
-        OperationTypes.MedicalActs,
-        ccamMedicalAct.toDF,
-        Path(bulkConfig.output.outputSavePath),
-        bulkConfig.output.saveMode
-      )
-    }
-
-    ccamMedicalAct.unpersist()
 
 
     val liberalActs = McoCeActExtractor.extract(sources, Set.empty).cache()

--- a/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/DcirMedicalActsSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/DcirMedicalActsSuite.scala
@@ -219,14 +219,15 @@ class DcirMedicalActsSuite extends SharedContext {
     val codes = Set("AAAA", "CCCC")
 
     val input = Seq(
-      ("Patient_A", "AAAA", makeTS(2010, 1, 1), None, None, None),
-      ("Patient_A", "BBBB", makeTS(2010, 2, 1), Some(1D), Some(0D), Some(1D)),
-      ("Patient_B", "CCCC", makeTS(2010, 3, 1), None, None, None),
-      ("Patient_B", "CCCC", makeTS(2010, 4, 1), Some(7D), Some(0D), Some(2D)),
-      ("Patient_C", "BBBB", makeTS(2010, 5, 1), Some(1D), Some(0D), Some(2D))
+      ("Patient_A", "AAAA", makeTS(2010, 1, 1), None, None, None, makeTS(2010, 1, 1)),
+      ("Patient_A", "BBBB", makeTS(2010, 2, 1), Some(1D), Some(0D), Some(1D), makeTS(2010, 1, 1)),
+      ("Patient_B", "CCCC", makeTS(2010, 3, 1), None, None, None, makeTS(2010, 1, 1)),
+      ("Patient_B", "CCCC", makeTS(2010, 4, 1), Some(7D), Some(0D), Some(2D), makeTS(2010, 1, 1)),
+      ("Patient_C", "BBBB", makeTS(2010, 5, 1), Some(1D), Some(0D), Some(2D), makeTS(2010, 1, 1))
     ).toDF(
       ColNames.PatientID, ColNames.CamCode, ColNames.Date,
-      ColNames.InstitutionCode, ColNames.GHSCode, ColNames.Sector
+      ColNames.InstitutionCode, ColNames.GHSCode, ColNames.Sector,
+      ColNames.DcirFluxDate
     )
 
     val sources = Sources(dcir = Some(input))

--- a/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoMedicalActsSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/acts/McoMedicalActsSuite.scala
@@ -59,9 +59,9 @@ class McoMedicalActsSuite extends SharedContext {
     val ccamCodes = Set("AAAA123")
     val mco = spark.read.parquet("src/test/resources/test-input/MCO.parquet")
     val expected = Seq[Event[MedicalAct]](
-      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 29)),
-      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 29)),
-      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 8))
+      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 31)),
+      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 31)),
+      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 10))
     ).toDS
 
     val input = Sources(mco = Some(mco))
@@ -79,12 +79,12 @@ class McoMedicalActsSuite extends SharedContext {
     // Given
     val mco = spark.read.parquet("src/test/resources/test-input/MCO.parquet")
     val expected = Seq[Event[MedicalAct]](
-      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 29)),
-      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 29)),
-      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 8)),
-      McoCCAMAct("Patient_02", "10000123_20000345_2007", "BBBB123", makeTS(2007, 1, 29)),
-      McoCCAMAct("Patient_02", "10000123_10000543_2006", "BBBB123", makeTS(2005, 12, 24)),
-      McoCCAMAct("Patient_02", "10000123_30000852_2008", "BBBB123", makeTS(2008, 3, 15))
+      McoCCAMAct("Patient_02", "10000123_10000987_2006", "AAAA123", makeTS(2005, 12, 31)),
+      McoCCAMAct("Patient_02", "10000123_20000123_2007", "AAAA123", makeTS(2007, 1, 31)),
+      McoCCAMAct("Patient_02", "10000123_30000546_2008", "AAAA123", makeTS(2008, 3, 10)),
+      McoCCAMAct("Patient_02", "10000123_20000345_2007", "BBBB123", makeTS(2007, 1, 31)),
+      McoCCAMAct("Patient_02", "10000123_10000543_2006", "BBBB123", makeTS(2005, 12, 26)),
+      McoCCAMAct("Patient_02", "10000123_30000852_2008", "BBBB123", makeTS(2008, 3, 17))
     ).toDS
 
     val input = Sources(mco = Some(mco))


### PR DESCRIPTION
An additional refinement for the Event date of Medical Acts sourcing from MCO. It add the delay to the start date of the hospitalisation to get the exact Event date.