### PR TITLE
CNAM-297: count fractures by DP, DA, DR in dataset

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtract.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/FallMainExtract.scala
@@ -14,11 +14,9 @@ import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.study.fall.codes._
 import fr.polytechnique.cmap.cnam.study.fall.config.FallConfig
 import fr.polytechnique.cmap.cnam.study.fall.extractors._
+import fr.polytechnique.cmap.cnam.study.fall.statistics.DiagnosisCounter
 import fr.polytechnique.cmap.cnam.util.Path
 import fr.polytechnique.cmap.cnam.util.reporting._
-import org.apache.spark.sql.{Dataset, SQLContext}
-
-import scala.collection.mutable
 
 object FallMainExtract extends Main with FractureCodes {
 
@@ -118,11 +116,13 @@ object FallMainExtract extends Main with FractureCodes {
     if (fallConfig.runParameters.diagnoses) {
       logger.info("diagnoses")
       val diagnoses = new DiagnosisExtractor(fallConfig.diagnoses).extract(sources).persist()
-      val diagnoses_report = OperationReporter.reportAsDataSet(
+      val diagnosesPopulation = DiagnosisCounter.process(diagnoses)
+      val diagnoses_report = OperationReporter.reportDataAndPopulationAsDataSet(
         "diagnoses",
         List("MCO", "IR_IMB_R"),
         OperationTypes.Diagnosis,
         diagnoses,
+        diagnosesPopulation,
         Path(fallConfig.output.outputSavePath),
         fallConfig.output.saveMode
       )

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/DiagnosisCounter.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/DiagnosisCounter.scala
@@ -1,0 +1,46 @@
+package fr.polytechnique.cmap.cnam.study.fall.statistics
+
+import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.sql.{Dataset, Encoder, Encoders, TypedColumn}
+import fr.polytechnique.cmap.cnam.etl.events._
+
+case class DiagnosisStat(patientID: String, dp: Int, da: Int, dr: Int) extends Statistical
+
+object DiagnosisCounter extends EventStatistics[Diagnosis, DiagnosisStat] {
+  //monoid type in order to aggregate overs diagnosis in dataset
+  //https://docs.databricks.com/_static/notebooks/dataset-aggregator.html
+  //https://medium.com/build-and-learn/spark-aggregating-your-data-the-fast-way-e37b53314fad
+  private val sumOf: TypedColumn[DiagnosisStat, DiagnosisStat] = new Aggregator[DiagnosisStat, DiagnosisStat, DiagnosisStat] with Serializable {
+    override def zero: DiagnosisStat = DiagnosisStat("", 0, 0, 0)
+
+    override def reduce(b: DiagnosisStat, a: DiagnosisStat): DiagnosisStat =
+      DiagnosisStat("", b.dp + a.dp, b.da + a.da, b.dr + a.dr)
+
+    override def merge(b1: DiagnosisStat, b2: DiagnosisStat): DiagnosisStat =
+      DiagnosisStat("", b1.dp + b2.dp, b1.da + b2.da, b1.dr + b2.dr)
+
+    override def finish(reduction: DiagnosisStat): DiagnosisStat = reduction
+
+    override def bufferEncoder: Encoder[DiagnosisStat] = Encoders.product[DiagnosisStat]
+
+    override def outputEncoder: Encoder[DiagnosisStat] = Encoders.product[DiagnosisStat]
+  }.toColumn
+
+  override def process(ds: Dataset[Event[Diagnosis]]): Dataset[DiagnosisStat] = {
+    val context = ds.sqlContext
+    import context.implicits._
+
+    ds.map {
+      event =>
+        event.category match {
+          case McoMainDiagnosis.category => DiagnosisStat(event.patientID, 1, 0, 0)
+          case McoAssociatedDiagnosis.category => DiagnosisStat(event.patientID, 0, 1, 0)
+          case McoLinkedDiagnosis.category => DiagnosisStat(event.patientID, 0, 0, 1)
+          case _ => DiagnosisStat(event.patientID, 0, 0, 0)
+        }
+    }.groupByKey(_.patientID).agg(sumOf).map {
+      case (patientID, DiagnosisStat(_, dp, da, dr)) => DiagnosisStat(patientID, dp, da, dr)
+    }
+
+  }
+}

--- a/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/EventStatistics.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/EventStatistics.scala
@@ -1,0 +1,12 @@
+package fr.polytechnique.cmap.cnam.study.fall.statistics
+
+import org.apache.spark.sql.Dataset
+import fr.polytechnique.cmap.cnam.etl.events.{AnyEvent, Event}
+
+trait Statistical
+
+trait EventStatistics[A <: AnyEvent, B <: Statistical] {
+  def process(ds: Dataset[Event[A]]): Dataset[B]
+}
+
+

--- a/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/DiagnosisCounterSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/study/fall/statistics/DiagnosisCounterSuite.scala
@@ -1,0 +1,53 @@
+package fr.polytechnique.cmap.cnam.study.fall.statistics
+
+import fr.polytechnique.cmap.cnam.SharedContext
+import fr.polytechnique.cmap.cnam.etl.events._
+import fr.polytechnique.cmap.cnam.util.functions.makeTS
+
+class DiagnosisCounterSuite extends SharedContext {
+
+  it should "count fractures by DP, DA, DR" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+
+    val input = Seq[Event[Diagnosis]](
+      McoMainDiagnosis("Patient_02", "10000123_20000123_2007", "C670", makeTS(2007, 1, 29)),
+      McoMainDiagnosis("Patient_02", "10000123_20000345_2007", "C671", makeTS(2007, 1, 29)),
+      McoMainDiagnosis("Patient_02", "10000123_10000987_2006", "C670", makeTS(2005, 12, 29)),
+      McoMainDiagnosis("Patient_02", "10000123_10000543_2006", "C671", makeTS(2005, 12, 24)),
+      McoMainDiagnosis("Patient_02", "10000123_30000546_2008", "C670", makeTS(2008, 3, 8)),
+      McoMainDiagnosis("Patient_02", "10000123_30000852_2008", "C671", makeTS(2008, 3, 15)),
+      McoLinkedDiagnosis("Patient_02", "10000123_20000123_2007", "E05", makeTS(2007, 1, 29)),
+      McoLinkedDiagnosis("Patient_02", "10000123_10000543_2006", "E08", makeTS(2005, 12, 24)),
+      McoAssociatedDiagnosis("Patient_02", "10000123_20000123_2007", "C66.5", makeTS(2007, 1, 29)),
+      McoAssociatedDiagnosis("Patient_02", "10000123_10000543_2006", "C66.9", makeTS(2005, 12, 24)),
+      McoMainDiagnosis("Patient_05", "10000123_20000123_2007", "C670", makeTS(2007, 1, 29)),
+      McoMainDiagnosis("Patient_06", "10000123_20000123_2007", "C670", makeTS(2007, 1, 29)),
+      McoLinkedDiagnosis("Patient_06", "10000123_10000543_2006", "E08", makeTS(2005, 12, 24))
+    ).toDS
+
+    val expected = Seq[DiagnosisStat](
+      DiagnosisStat("Patient_05", 1, 0, 0),
+      DiagnosisStat("Patient_02", 6, 2, 2),
+      DiagnosisStat("Patient_06", 1, 0, 1)
+    ).toDS()
+
+    val population = DiagnosisCounter.process(input)
+
+    assertDSs(expected, population)
+
+  }
+
+  it should "return zero if dataset is empty" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+
+    val input = Seq.empty[Event[Diagnosis]].toDS()
+
+    val population = DiagnosisCounter.process(input)
+
+    assert(population.count() == 0)
+
+  }
+
+}


### PR DESCRIPTION
This is an experimental task consisting of the count of diagnosis by  DP, DA, DR in pure dataset.

I created a simple trait EventStatistics in order to count the population of any type of events in the fall and I implemented DiagnosisCounter to count  fractures by DP, DA, DR for every patients.