### PR TITLE
Added an end Date to IrImb DiagnosisExtractor

### DIFF
--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Diagnosis.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/events/Diagnosis.scala
@@ -13,6 +13,10 @@ trait Diagnosis extends AnyEvent with EventBuilder {
     Event(patientID, category, groupID = "NA", code, 0.0, date, None)
   }
 
+  def apply(patientID: String, code: String, date: Timestamp, endDate: Option[Timestamp]): Event[Diagnosis] = {
+    Event(patientID, category, groupID = "NA", code, 0.0, date, endDate)
+  }
+
   def apply(patientID: String, groupID: String, code: String, date: Timestamp): Event[Diagnosis] = {
     Event(patientID, category, groupID, code, 0.0, date, None)
   }
@@ -20,6 +24,7 @@ trait Diagnosis extends AnyEvent with EventBuilder {
   def apply(patientID: String, groupID: String, code: String, weight: Double, date: Timestamp): Event[Diagnosis] = {
     Event(patientID, category, groupID, code, weight, date, None)
   }
+
 }
 
 object McoMainDiagnosis extends Diagnosis {

--- a/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/ImbDiagnosisExtractor.scala
+++ b/src/main/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/ImbDiagnosisExtractor.scala
@@ -2,12 +2,19 @@
 
 package fr.polytechnique.cmap.cnam.etl.extractors.diagnoses
 
+import scala.util.Try
+
 import java.sql.{Date, Timestamp}
+
 import org.apache.spark.sql.{DataFrame, Row}
+
 import fr.polytechnique.cmap.cnam.etl.events.{Diagnosis, Event, ImbDiagnosis}
 import fr.polytechnique.cmap.cnam.etl.extractors.Extractor
 import fr.polytechnique.cmap.cnam.etl.sources.Sources
 import fr.polytechnique.cmap.cnam.util.datetime
+import fr.polytechnique.cmap.cnam.util.datetime.implicits._
+import fr.polytechnique.cmap.cnam.util.functions.makeTS
+
 
 object ImbDiagnosisExtractor extends Extractor[Diagnosis] with ImbSource {
 
@@ -17,14 +24,21 @@ object ImbDiagnosisExtractor extends Extractor[Diagnosis] with ImbSource {
   }
 
   override def isInStudy(codes: Set[String])
-    (row: Row): Boolean = codes.exists(getCode(row).startsWith(_))
+                        (row: Row): Boolean = codes.exists(getCode(row).startsWith(_))
 
   override def builder(row: Row): Seq[Event[Diagnosis]] =
-    Seq(ImbDiagnosis(getPatientID(row), getCode(row), getEventDate(row)))
+    Seq(ImbDiagnosis(getPatientID(row), getCode(row), getEventDate(row), getEventEnd(row)))
 
   override def getInput(sources: Sources): DataFrame = sources.irImb.get
 }
 
+/** IR_IMB_R contains the Chronic Diseases diagnoses (ALD = Affection Longue Duree) for patients once
+  * they have been exonerated for all cares related to this Chronic Disease.
+  * It is the medical service of the health insurance  that grants this ALD on the proposal of the
+  * patient's main physician (Medecin Traitant).
+  * See the [online snds documentation for further details](https://documentation-snds.health-data-hub.fr/fiches/beneficiaires_ald.html#le-dispositif-des-ald)
+  *
+  */
 trait ImbSource extends Serializable {
 
   lazy val getCode = (row: Row) => row.getAs[String](ColNames.Code)
@@ -39,11 +53,35 @@ trait ImbSource extends Serializable {
     row.getAs[Date](ColNames.Date).toTimestamp
   }
 
+  /**
+    * The End date of the ALD is not always written. It can takes the value 1600-01-01 which
+    * corresponds to a None value (not set) that we convert to None.
+    * See the CNAM documentation [available here](https://documentation-snds.health-data-hub.fr/fiches/beneficiaires_ald.html#annexe)
+    *
+    * @param r
+    * @return
+    */
+  def getEventEnd(r: Row): Option[Timestamp] = {
+    Try({
+      val rawEndDate = r.getAs[java.util.Date](ColNames.EndDate).toTimestamp
+
+      if (makeTS(1700, 1 ,1).after(rawEndDate)){
+        None
+      }
+      else {
+        Some(rawEndDate)
+      }
+    }) recover {
+    case _: NullPointerException => None
+    }
+    }.get
+
   final object ColNames extends Serializable {
     final lazy val PatientID = "NUM_ENQ"
     final lazy val Encoding = "MED_NCL_IDT"
     final lazy val Code = "MED_MTF_COD"
     final lazy val Date = "IMB_ALD_DTD"
+    final lazy val EndDate = "IMB_ALD_DTF"
   }
 
 }

--- a/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/ImbDiagnosesSuite.scala
+++ b/src/test/scala/fr/polytechnique/cmap/cnam/etl/extractors/diagnoses/ImbDiagnosesSuite.scala
@@ -15,7 +15,7 @@ class ImbDiagnosesSuite extends SharedContext {
 
     // Given
     val imb = sqlContext.read.load("src/test/resources/test-input/IR_IMB_R.parquet")
-    val expected = Seq(ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13))).toDS
+    val expected = Seq(ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13), Some(makeTS(2016, 3, 13)))).toDS
 
     val sources = Sources(irImb = Some(imb))
     // When
@@ -32,14 +32,42 @@ class ImbDiagnosesSuite extends SharedContext {
     // Given
     val imb = sqlContext.read.load("src/test/resources/test-input/IR_IMB_R.parquet")
     val expected = Seq(
-      ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13)),
-      ImbDiagnosis("Patient_02", "E11", makeTS(2006, 1, 25)),
-      ImbDiagnosis("Patient_02", "9999", makeTS(2006, 4, 25))
+      ImbDiagnosis("Patient_02", "E11", makeTS(2006, 1, 25), Some(makeTS(2011, 1, 24))),
+      ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13), Some(makeTS(2016, 3, 13))),
+      ImbDiagnosis("Patient_02", "9999", makeTS(2006, 4, 25), Some(makeTS(2016, 4, 25)))
     ).toDS
 
     val sources = Sources(irImb = Some(imb))
     // When
-    val output = ImbDiagnosisExtractor.extract(sources, Set.empty)
+    val output = ImbDiagnosisExtractor.extract(sources, Set.empty).orderBy($"start".asc)
+
+    // Then
+    assertDSs(expected, output)
+  }
+
+  it should "extract all diagnosis events from raw data when an Empty codes is passed even when ir_imb_f is null" in {
+    val sqlCtx = sqlContext
+    import sqlCtx.implicits._
+
+    // Given
+    //val imb = sqlContext.read.load("src/test/resources/test-input/IR_IMB_R_null.parquet")
+    val imb = Seq(
+      ("Patient_02", "CIM10", "E11", makeTS(2006, 1, 25), Some(makeTS(2011, 1, 24))),
+      ("Patient_02", "CIM10", "C67", makeTS(2006, 3, 13), Some(makeTS(1600, 1, 1))),
+      ("Patient_03", "CIM10", "C67", makeTS(2006, 3, 13), None),
+      ("Patient_02", "CIM10", "9999", makeTS(2006, 4, 25), Some(makeTS(2016, 4, 25)))
+    ).toDF("NUM_ENQ", "MED_NCL_IDT", "MED_MTF_COD", "IMB_ALD_DTD", "IMB_ALD_DTF")
+
+    val expected = Seq(
+      ImbDiagnosis("Patient_02", "E11", makeTS(2006, 1, 25), Some(makeTS(2011, 1, 24))),
+      ImbDiagnosis("Patient_02", "C67", makeTS(2006, 3, 13), None),
+      ImbDiagnosis("Patient_03", "C67", makeTS(2006, 3, 13), None),
+      ImbDiagnosis("Patient_02", "9999", makeTS(2006, 4, 25), Some(makeTS(2016, 4, 25)))
+    ).toDS
+
+    val sources = Sources(irImb = Some(imb))
+    // When
+    val output = ImbDiagnosisExtractor.extract(sources, Set.empty).orderBy($"start".asc)
 
     // Then
     assertDSs(expected, output)


### PR DESCRIPTION
IrImb diagnosis should be handled carefully in studies. 

When used to characterize a patient, the IrImb diagnosis (ALD = Affection Longue Duree) should be active during the period of study. Thus we extract the endDate of ALD for IrImbDiagnosis.